### PR TITLE
feat: Do not call toSearchableArray when deleting models

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -21,7 +21,7 @@ final class Engine extends BaseEngine
         $model = $models->first();
         $index = $model->searchableAs();
         $routingPath = in_array(ShardRouting::class, class_uses_recursive($model)) ? $model->getRoutingPath() : null;
-        $documents = $this->documentFactory->makeFromModels($models);
+        $documents = $this->documentFactory->makeFromModels($models, false);
 
         $this->documentManager->index($index, $documents->all(), $this->refreshDocuments, $routingPath);
     }
@@ -38,7 +38,7 @@ final class Engine extends BaseEngine
         $model = $models->first();
         $index = $model->searchableAs();
         $routingPath = in_array(ShardRouting::class, class_uses_recursive($model)) ? $model->getRoutingPath() : null;
-        $documents = $this->documentFactory->makeFromModels($models);
+        $documents = $this->documentFactory->makeFromModels($models, true);
 
         $this->documentManager->delete($index, $documents->all(), $this->refreshDocuments, $routingPath);
     }


### PR DESCRIPTION
When deleting models from search, we do not need to provide Elasticsearch with the full model data, just the "_id" field so that Elasticsearch knows which document to delete. Calling toSearchableArray on models that have been deleted from the database can cause issues if relations etc cannot be hydrated, and also creates an unnecessary database call. This commit makes use of a new optional argument in "elastic-scout-driver" DocumentFactory which indicates if we want to call toSearchableArray on the models or not.