### PR TITLE
Added `innerHits()` to `Decorator\Hit` 

### DIFF
--- a/src/Decorators/Hit.php
+++ b/src/Decorators/Hit.php
@@ -47,7 +47,7 @@ final class Hit implements Arrayable
         return $this->forwardCallTo($this->hit, $method, $parameters);
     }
 
-    public function inner_hits()
+    public function innerHits()
     {
         $final_inner_hits = [];
         $raw_hit = $this->hit->raw();

--- a/src/Decorators/SearchResult.php
+++ b/src/Decorators/SearchResult.php
@@ -63,6 +63,13 @@ final class SearchResult implements IteratorAggregate
         })->filter()->values();
     }
 
+    public function inner_hits(): Collection
+    {
+        return $this->hits()->map(static function (Hit $hit) {
+            return $hit->inner_hits();
+        })->filter()->values();
+    }
+
     /**
      * @return ArrayIterator<int, Hit>
      */

--- a/src/Decorators/SearchResult.php
+++ b/src/Decorators/SearchResult.php
@@ -63,10 +63,10 @@ final class SearchResult implements IteratorAggregate
         })->filter()->values();
     }
 
-    public function inner_hits(): Collection
+    public function innerHits(): Collection
     {
         return $this->hits()->map(static function (Hit $hit) {
-            return $hit->inner_hits();
+            return $hit->innerHits();
         })->filter()->values();
     }
 


### PR DESCRIPTION
It just add the `inner_hits` to the `Hit` interface. I'm just performing it by using raw query on the `SearchQueryBuilder`.
[Used for inner hits on ](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-inner-hits.html)