### PR TITLE
Don't override remove from search if driver is not elastic

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -28,7 +28,7 @@ final class ServiceProvider extends AbstractServiceProvider
      */
     public function register()
     {
-        if (property_exists(Scout::class, 'removeFromSearchJob')) {
+        if (config('scout.driver') === 'elastic' && property_exists(Scout::class, 'removeFromSearchJob')) {
             Scout::$removeFromSearchJob = RemoveFromSearch::class;
         }
     }


### PR DESCRIPTION
Otherwise, if you use a different driver in a test environment for example, deleting a model will still use the elastic driver.