### PR TITLE
Check that Scout driver is elastic before dispatching RemoveFromSearch

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -11,7 +11,9 @@ use Laravel\Scout\Searchable as BaseSearchable;
 
 trait Searchable
 {
-    use BaseSearchable;
+    use BaseSearchable {
+        queueRemoveFromSearch as public parentQueueRemoveFromSearch;
+    }
 
     /**
      * @param Closure|QueryBuilderInterface|array $query
@@ -46,6 +48,10 @@ trait Searchable
     {
         if ($models->isEmpty()) {
             return;
+        }
+        
+        if (config('scout.driver') !== 'elastic') {
+            return $this->parentQueueRemoveFromSearch($models);
         }
 
         if (!config('scout.queue')) {


### PR DESCRIPTION
Similar to my previous PR, there is an issue where the RemoveFromSearch event gets dispatched even when using a different Scout driver like collection in a test environment.