### PR TITLE
[v3.5.0] Add return type to SearchResult::getIterator so it remove ugly PHP Deprecated message

### DIFF
--- a/src/Decorators/SearchResult.php
+++ b/src/Decorators/SearchResult.php
@@ -69,7 +69,7 @@ final class SearchResult implements IteratorAggregate
     /**
      * @return ArrayIterator<int, Hit>
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return $this->hits()->getIterator();
     }


### PR DESCRIPTION
Currently when we are running unit tests in our PHP 8.1 project there is ugly message

```php
PHP Deprecated:  Return type of ElasticScoutDriverPlus\Decorators\SearchResult::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/vendor/babenkoivan/elastic-scout-driver-plus/src/Decorators/SearchResult.php on line 72
```

This should fix this message

Tests passing

![image](https://user-images.githubusercontent.com/3932546/213400116-98f92b3a-7638-48bd-b022-f9a3bec56d4d.png)


Code style
```php
make style-check 
→ Checking the code style
PHP CS Fixer 3.13.2 Oliva by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 8.1.2-1ubuntu2.9
Loaded config default from "/home/rolla/code/yopa/devs-docker/api-v2/vendor/babenkoivan/elastic-scout-driver-plus/.php-cs-fixer.dist.php".
.....................................................................................................................................................                                           149 / 149 (100%)
Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error

Found 0 of 149 files that can be fixed in 1.303 seconds, 18.000 MB memory used

Detected deprecations in use:
- Rule "no_trailing_comma_in_singleline_array" is deprecated. Use "no_trailing_comma_in_singleline" instead.

✔︎ Code style is checked

```

Static analysis

```php
 [OK] No errors                                                                                                         
                                                                                                                        
✔︎ Code static analysis is completed
```
