### PR TITLE
Add Macroable trait to SearchParametersBuilder

### DIFF
--- a/src/Builders/SearchParametersBuilder.php
+++ b/src/Builders/SearchParametersBuilder.php
@@ -15,11 +15,13 @@ use Elastic\ScoutDriverPlus\Searchable;
 use Elastic\ScoutDriverPlus\Support\Arr;
 use Elastic\ScoutDriverPlus\Support\Conditionable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
 class SearchParametersBuilder
 {
     use Conditionable;
+    use Macroable;
 
     public const DEFAULT_PAGE_SIZE = 10;
 


### PR DESCRIPTION
This PR allows SearchParametersBuilder to be Macroable.
This is very useful when trying to do things like spatie/laravel-json-api-paginate does.

For example, this allows a user to alias a custom pagination method which uses other query parameters than the ones provided by Laravel.

This would make it on-par with laravel/scouts Builder, [which is already Macroable](https://github.com/laravel/scout/blob/72a898a9555e1b0061ab2fb1d4eb74f9e15c76a5/src/Builder.php#L14).