### PR TITLE
Fix implicitly nullable parameter declarations in PHP 8.4

### DIFF
--- a/src/Builders/SearchParametersBuilder.php
+++ b/src/Builders/SearchParametersBuilder.php
@@ -198,7 +198,7 @@ class SearchParametersBuilder
         return $this;
     }
 
-    public function join(string $modelClass, float $boost = null): self
+    public function join(string $modelClass, ?float $boost = null): self
     {
         if (
             !is_a($modelClass, Model::class, true) ||
@@ -231,7 +231,7 @@ class SearchParametersBuilder
         return $this;
     }
 
-    public function load(array $relations, string $modelClass = null): self
+    public function load(array $relations, ?string $modelClass = null): self
     {
         $indexName = $this->resolveJoinedIndexName($modelClass);
         $this->databaseQueryBuilders[$indexName]->with($relations);
@@ -239,7 +239,7 @@ class SearchParametersBuilder
         return $this;
     }
 
-    public function refineModels(Closure $callback, string $modelClass = null): self
+    public function refineModels(Closure $callback, ?string $modelClass = null): self
     {
         $indexName = $this->resolveJoinedIndexName($modelClass);
         $this->databaseQueryBuilders[$indexName]->callback($callback);
@@ -432,7 +432,7 @@ class SearchParametersBuilder
     public function paginate(
         int $perPage = self::DEFAULT_PAGE_SIZE,
         string $pageName = 'page',
-        int $page = null
+        ?int $page = null
     ): Paginator {
         $page = $page ?? Paginator::resolveCurrentPage($pageName);
 

--- a/src/Support/Conditionable.php
+++ b/src/Support/Conditionable.php
@@ -13,7 +13,7 @@ trait Conditionable
     /**
      * @param mixed $value
      */
-    public function when($value, callable $callback, callable $default = null): self
+    public function when($value, callable $callback, ?callable $default = null): self
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
@@ -33,7 +33,7 @@ trait Conditionable
      *
      * @return $this
      */
-    public function unless($value, callable $callback, callable $default = null): self
+    public function unless($value, callable $callback, ?callable $default = null): self
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 


### PR DESCRIPTION
See: <https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated>

use [rector](https://github.com/rectorphp/rector) auto fix:

rules:

- ExplicitNullableParamTypeRector