### PR TITLE
Bugfix for L13

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -35,6 +35,6 @@ final class ServiceProvider extends AbstractServiceProvider
             Scout::removeFromSearchUsing(RemoveFromSearch::class);
         }
 
-        resolve(EngineManager::class)->extend('null', static fn () => resolve(NullEngine::class));
+        resolve(EngineManager::class)->extend('null', fn () => resolve(NullEngine::class));
     }
 }


### PR DESCRIPTION
Laravel 13 now duplicates the closure with a new bound object and class scope. Static closures cannot have any bound object. 

https://github.com/laravel/framework/pull/57173

https://github.com/laravel/framework/blob/62df898ced958f7e10b3780074ce3b406e562c48/src/Illuminate/Support/Manager.php#L130